### PR TITLE
Add missing market parameters

### DIFF
--- a/manifold/api.py
+++ b/manifold/api.py
@@ -90,6 +90,8 @@ class Market:
     # Separating into two FullMarket types would be pointlessly annoying
     bets: Optional[List[Bet]] = field(kw_only=True, default=None)
     comments: Optional[List[Bet]] = field(kw_only=True, default=None)
+    outcomeType: str
+    volume: float
 
     def get_updates(self) -> Tuple[np.ndarray, np.ndarray]:
         """Get all updates to this market.


### PR DESCRIPTION
Looks like Manifold added more parameters to their API. All parameters in the JSON response must have matching class parameters or it throws an exception